### PR TITLE
PHP7 compatibility

### DIFF
--- a/responsible.php
+++ b/responsible.php
@@ -33,7 +33,7 @@ class responsible {
 	 * @return void
 	 * @author Scott Evans
 	 */
-	function responsible() {
+	function __construct() {
 		add_action( 'admin_bar_menu', array( $this, "responsible_menu" ), 100);
 		add_action( 'wp_enqueue_scripts', array( $this, "responsible_css" ) );
 		add_action( 'admin_enqueue_scripts', array( $this, "responsible_css" ) );


### PR DESCRIPTION
Methods with the same name as their class will not be constructors in a future version of PHP; responsible has a deprecated constructor
