### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/responsible.php
+++ b/responsible.php
@@ -64,7 +64,7 @@ class responsible {
 	 * @return void
 	 * @author Scott Evans
 	 */
-	function add_root_menu($name, $id, $href = FALSE) {
+	function add_root_menu($name, $id, $href = false) {
 
 		global $wp_admin_bar;
 
@@ -91,7 +91,7 @@ class responsible {
 	 * @return void
 	 * @author Scott Evans
 	 */
-	function add_sub_menu($name, $link, $root_menu, $id, $meta = FALSE) {
+	function add_sub_menu($name, $link, $root_menu, $id, $meta = false) {
 
 		global $wp_admin_bar;
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!